### PR TITLE
Add basic support for derivatives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ readme = "README.md"
 edition = "2018"
 
 [lib]
-crate-type = ["cdylib"]
+name = "nabla_game"
+crate-type = ["cdylib", "rlib"]
 
 [profile.release]
 # This makes the compiled code faster and smaller, but it makes compiling slower,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"build": "rimraf dist pkg && webpack",
 		"start": "rimraf dist pkg && webpack serve --live-reload --watch-files=src --open --hot",
 		"watch": "rimraf dist pkg && webpack --watch",
-		"test": "cargo test && wasm-pack test --headless"
+		"test": "cargo test && wasm-pack test --headless --chrome"
 	},
 	"devDependencies": {
 		"@wasm-tool/wasm-pack-plugin": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
 		"build": "rimraf dist pkg && webpack",
 		"start": "rimraf dist pkg && webpack serve --live-reload --watch-files=src --open --hot",
 		"watch": "rimraf dist pkg && webpack --watch",
-		"test": "cargo test && wasm-pack test --headless --chrome"
+		"test:print": "cargo test -- --no-capture",
+		"test:cargo": "cargo test",
+		"test:wasm": "wasm-pack test --headless --chrome",
+		"test": "yarn test:cargo && yarn test:wasm"
 	},
 	"devDependencies": {
 		"@wasm-tool/wasm-pack-plugin": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"build": "rimraf dist pkg && webpack",
 		"start": "rimraf dist pkg && webpack serve --live-reload --watch-files=src --open --hot",
 		"watch": "rimraf dist pkg && webpack --watch",
-		"test:print": "cargo test -- --no-capture",
+		"test:print": "cargo test -- --nocapture",
 		"test:cargo": "cargo test",
 		"test:wasm": "wasm-pack test --headless --chrome",
 		"test": "yarn test:cargo && yarn test:wasm"

--- a/src/basis.rs
+++ b/src/basis.rs
@@ -92,3 +92,82 @@ impl EnumStr<BasisOperator> for BasisOperator {
         }
     }
 }
+
+#[allow(non_snake_case)]
+pub fn AddBasisNode(left_operand: &Basis, right_operand: &Basis) -> Basis {
+    if let Basis::BasisCard(BasisCard::Zero) = left_operand {
+        return right_operand.clone();
+    } else if let Basis::BasisCard(BasisCard::Zero) = right_operand {
+        return left_operand.clone();
+    } else if left_operand == right_operand {
+        // verify equality check
+        return left_operand.clone();
+    }
+
+    Basis::BasisNode(BasisNode {
+        operator: BasisOperator::Add,
+        left_operand: Box::new(left_operand.clone()),
+        right_operand: Box::new(right_operand.clone()),
+    })
+}
+
+#[allow(non_snake_case)]
+pub fn MinusBasisNode(left_operand: &Basis, right_operand: &Basis) -> Basis {
+    if let Basis::BasisCard(BasisCard::Zero) = right_operand {
+        return left_operand.clone();
+    } else if left_operand == right_operand {
+        // verify equality check
+        return Basis::BasisCard(BasisCard::Zero);
+    }
+
+    Basis::BasisNode(BasisNode {
+        operator: BasisOperator::Minus,
+        left_operand: Box::new(left_operand.clone()),
+        right_operand: Box::new(right_operand.clone()),
+    })
+}
+
+#[allow(non_snake_case)]
+pub fn MultBasisNode(left_operand: &Basis, right_operand: &Basis) -> Basis {
+    if matches!(left_operand, Basis::BasisCard(BasisCard::One)) {
+        return right_operand.clone();
+    } else if matches!(right_operand, Basis::BasisCard(BasisCard::One)) {
+        return left_operand.clone();
+    }
+    return Basis::BasisNode(BasisNode {
+        operator: BasisOperator::Mult,
+        left_operand: Box::new(left_operand.clone()),
+        right_operand: Box::new(right_operand.clone()),
+    });
+}
+
+#[allow(non_snake_case)]
+pub fn DivBasisNode(left_operand: &Basis, right_operand: &Basis) -> Basis {
+    return Basis::BasisNode(BasisNode {
+        operator: BasisOperator::Div,
+        left_operand: Box::new(left_operand.clone()),
+        right_operand: Box::new(right_operand.clone()),
+    });
+}
+
+#[allow(non_snake_case)]
+pub fn PowBasisNode(n: i32, left_operand: &Basis) -> Basis {
+    if matches!(left_operand, Basis::BasisCard(BasisCard::X)) && n == 2 {
+        return Basis::BasisCard(BasisCard::X2);
+    }
+
+    Basis::BasisNode(BasisNode {
+        operator: BasisOperator::Pow(n),
+        left_operand: Box::new(left_operand.clone()),
+        right_operand: Box::new(Basis::BasisCard(BasisCard::Zero)), // dummy, unused
+    })
+}
+
+#[allow(non_snake_case)]
+pub fn SqrtBasisNode(n: i32, left_operand: &Basis) -> Basis {
+    Basis::BasisNode(BasisNode {
+        operator: BasisOperator::Sqrt(n),
+        left_operand: Box::new(left_operand.clone()),
+        right_operand: Box::new(Basis::BasisCard(BasisCard::Zero)), // dummy, unused
+    })
+}

--- a/src/basis.rs
+++ b/src/basis.rs
@@ -1,16 +1,14 @@
-use std::collections::HashMap;
-
 use super::game::EnumStr;
 
 // type union of the starter basis or complex basis
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Basis {
     BasisCard(BasisCard),
     BasisNode(BasisNode),
 }
 
 // used for complex bases derived from the starter cards
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BasisNode {
     pub operator: BasisOperator,
     // Box heap allocates, prevents recursive struct reference
@@ -18,7 +16,7 @@ pub struct BasisNode {
     pub right_operand: Box<Basis>,
 }
 
-#[derive(Hash, Eq, PartialEq, Copy, Clone, Debug)]
+#[derive(Hash, Copy, Clone, Debug, Eq, PartialEq)]
 pub enum BasisCard {
     Zero,
     One,
@@ -56,7 +54,7 @@ impl EnumStr<BasisCard> for BasisCard {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum BasisOperator {
     Add,
     Minus,

--- a/src/basis.rs
+++ b/src/basis.rs
@@ -1,6 +1,6 @@
-use super::game::EnumStr;
-
 use std::collections::HashMap;
+
+use super::game::EnumStr;
 
 pub trait BasisType {
     fn basis_type(&self) -> &'static str;
@@ -9,7 +9,7 @@ pub trait BasisType {
 }
 
 // type union of the starter basis or complex basis
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Basis {
     BasisNode(BasisNode),
     BasisCard(BasisCard),
@@ -40,7 +40,7 @@ impl BasisType for Basis {
 }
 
 // used for complex bases derived from the starter cards
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct BasisNode {
     pub operator: BasisOperator,
     // Vec heap allocates, prevents recursive struct reference
@@ -49,6 +49,7 @@ pub struct BasisNode {
     // 2 items only for pow, div (use [Basis; 2] ?)
     // mult, add could be arbitrary num (usually 2, maybe 3)
 }
+
 #[derive(Hash, Eq, PartialEq, Copy, Clone, Debug)]
 pub enum BasisCard {
     Zero,
@@ -87,11 +88,11 @@ impl EnumStr<BasisCard> for BasisCard {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum BasisOperator {
     Mult,
     Add,
-    Pow,
+    Pow(i32),
     Div,
 }
 
@@ -100,7 +101,9 @@ impl EnumStr<BasisOperator> for BasisOperator {
         match s {
             "*" => Some(BasisOperator::Mult),
             "+" => Some(BasisOperator::Add),
-            "^" => Some(BasisOperator::Pow),
+            s if s.matches("[^]-?\\d+").count() > 0 => {
+                Some(BasisOperator::Pow(s[1..].parse::<i32>().unwrap()))
+            } // convert ^n to Pow(n)
             "/" => Some(BasisOperator::Div),
             _ => None,
         }
@@ -110,7 +113,7 @@ impl EnumStr<BasisOperator> for BasisOperator {
         match self {
             BasisOperator::Mult => "*",
             BasisOperator::Add => "+",
-            BasisOperator::Pow => "^",
+            BasisOperator::Pow(i) => format!("^{}", i),
             BasisOperator::Div => "/",
         }
     }

--- a/src/basis.rs
+++ b/src/basis.rs
@@ -59,7 +59,7 @@ pub enum BasisOperator {
     Add,
     Minus,
     Pow(i32),
-    Sqrt(i32), // Sqrt(n) = n-1/2, ie. 0 = -1/2, 1 = 1/2, 2 = 3/2
+    Sqrt(i32), // Sqrt(n) = n/2 (numerator), ie. -1, 1, 3
     Mult,
     Div,
 }
@@ -73,8 +73,8 @@ impl EnumStr<BasisOperator> for BasisOperator {
                 Some(BasisOperator::Pow(s[1..].parse::<i32>().unwrap()))
             } // convert ^n to Pow(n)
             s if s.matches("[^]-?\\d+(?=[/]2)").count() > 0 => Some(BasisOperator::Sqrt(
-                (s[4..(s.len() - 2)].parse::<i32>().unwrap() + 1) / 2,
-            )), // convert ^n/2 to Sqrt((n + 1)/2), -1/2 → 0, 1/2 → 1, 3/2 → 2
+                s[4..(s.len() - 2)].parse::<i32>().unwrap(),
+            )),
             "*" => Some(BasisOperator::Mult),
             "/" => Some(BasisOperator::Div),
             _ => None,
@@ -86,7 +86,7 @@ impl EnumStr<BasisOperator> for BasisOperator {
             BasisOperator::Add => "+",
             BasisOperator::Minus => "-",
             BasisOperator::Pow(i) => Box::leak(format!("^{}", i).into_boxed_str()), // TODO: remove box leak
-            BasisOperator::Sqrt(i) => Box::leak(format!("^{}/2", i * 2 - 1).into_boxed_str()), // TODO: remove box leak
+            BasisOperator::Sqrt(i) => Box::leak(format!("^{}/2", i).into_boxed_str()), // TODO: remove box leak
             BasisOperator::Mult => "*",
             BasisOperator::Div => "/",
         }

--- a/src/basis.rs
+++ b/src/basis.rs
@@ -2,41 +2,11 @@ use std::collections::HashMap;
 
 use super::game::EnumStr;
 
-pub trait BasisType {
-    fn basis_type(&self) -> &'static str;
-    fn as_basis_card(&self) -> BasisCard;
-    fn as_basis_node(self) -> BasisNode;
-}
-
 // type union of the starter basis or complex basis
 #[derive(Clone, Debug)]
 pub enum Basis {
-    BasisNode(BasisNode),
     BasisCard(BasisCard),
-}
-
-impl BasisType for Basis {
-    fn basis_type(&self) -> &'static str {
-        match self {
-            Basis::BasisCard(_) => "BASIS_CARD",
-            Basis::BasisNode(_) => "BASIS_NODE",
-        }
-    }
-    fn as_basis_card(&self) -> BasisCard {
-        if let Basis::BasisCard(basis_card) = self {
-            *basis_card
-        } else {
-            panic!("Not a BasisCard")
-        }
-    }
-
-    fn as_basis_node(self) -> BasisNode {
-        if let Basis::BasisNode(basis_node) = self {
-            basis_node
-        } else {
-            panic!("Not a BasisNode")
-        }
-    }
+    BasisNode(BasisNode),
 }
 
 // used for complex bases derived from the starter cards
@@ -88,7 +58,7 @@ impl EnumStr<BasisCard> for BasisCard {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum BasisOperator {
     Mult,
     Add,

--- a/src/basis.rs
+++ b/src/basis.rs
@@ -58,7 +58,8 @@ impl EnumStr<BasisCard> for BasisCard {
 pub enum BasisOperator {
     Add,
     Minus,
-    Pow(i32), // represent sqrt with negative integers, ie. ^1/2 = Pow(-1), use Div for actual reciprocals
+    Pow(i32),
+    Sqrt(i32), // Sqrt(n) = n-1/2, ie. 0 = -1/2, 1 = 1/2, 2 = 3/2
     Mult,
     Div,
 }
@@ -68,9 +69,12 @@ impl EnumStr<BasisOperator> for BasisOperator {
         match s {
             "+" => Some(BasisOperator::Add),
             "-" => Some(BasisOperator::Minus),
-            s if s.matches("[^]-?\\d+").count() > 0 => {
+            s if s.matches("[^]-?\\d+(?!=[/]2)").count() > 0 => {
                 Some(BasisOperator::Pow(s[1..].parse::<i32>().unwrap()))
             } // convert ^n to Pow(n)
+            s if s.matches("[^]-?\\d+(?=[/]2)").count() > 0 => Some(BasisOperator::Sqrt(
+                (s[4..(s.len() - 2)].parse::<i32>().unwrap() + 1) / 2,
+            )), // convert ^n/2 to Sqrt((n + 1)/2), -1/2 → 0, 1/2 → 1, 3/2 → 2
             "*" => Some(BasisOperator::Mult),
             "/" => Some(BasisOperator::Div),
             _ => None,
@@ -82,6 +86,7 @@ impl EnumStr<BasisOperator> for BasisOperator {
             BasisOperator::Add => "+",
             BasisOperator::Minus => "-",
             BasisOperator::Pow(i) => Box::leak(format!("^{}", i).into_boxed_str()), // TODO: remove box leak
+            BasisOperator::Sqrt(i) => Box::leak(format!("^{}/2", i * 2 - 1).into_boxed_str()), // TODO: remove box leak
             BasisOperator::Mult => "*",
             BasisOperator::Div => "/",
         }

--- a/src/basis.rs
+++ b/src/basis.rs
@@ -1,10 +1,42 @@
 use super::game::EnumStr;
 
+use std::collections::HashMap;
+
+pub trait BasisType {
+    fn basis_type(&self) -> &'static str;
+    fn as_basis_card(&self) -> BasisCard;
+    fn as_basis_node(self) -> BasisNode;
+}
+
 // type union of the starter basis or complex basis
 #[derive(Debug)]
 pub enum Basis {
     BasisNode(BasisNode),
     BasisCard(BasisCard),
+}
+
+impl BasisType for Basis {
+    fn basis_type(&self) -> &'static str {
+        match self {
+            Basis::BasisCard(_) => "BASIS_CARD",
+            Basis::BasisNode(_) => "BASIS_NODE",
+        }
+    }
+    fn as_basis_card(&self) -> BasisCard {
+        if let Basis::BasisCard(basis_card) = self {
+            *basis_card
+        } else {
+            panic!("Not a BasisCard")
+        }
+    }
+
+    fn as_basis_node(self) -> BasisNode {
+        if let Basis::BasisNode(basis_node) = self {
+            basis_node
+        } else {
+            panic!("Not a BasisNode")
+        }
+    }
 }
 
 // used for complex bases derived from the starter cards
@@ -17,7 +49,7 @@ pub struct BasisNode {
     // 2 items only for pow, div (use [Basis; 2] ?)
     // mult, add could be arbitrary num (usually 2, maybe 3)
 }
-#[derive(Copy, Clone, Debug)]
+#[derive(Hash, Eq, PartialEq, Copy, Clone, Debug)]
 pub enum BasisCard {
     Zero,
     One,

--- a/src/basis.rs
+++ b/src/basis.rs
@@ -83,7 +83,7 @@ impl EnumStr<BasisOperator> for BasisOperator {
         match self {
             BasisOperator::Add => "+",
             BasisOperator::Minus => "-",
-            BasisOperator::Pow(i) => format!("^{}", i),
+            BasisOperator::Pow(i) => Box::leak(format!("^{}", i).into_boxed_str()), // TODO: remove box leak
             BasisOperator::Mult => "*",
             BasisOperator::Div => "/",
         }

--- a/src/basis.rs
+++ b/src/basis.rs
@@ -15,7 +15,7 @@ pub struct BasisNode {
     pub operator: BasisOperator,
     // Box heap allocates, prevents recursive struct reference
     pub left_operand: Box<Basis>,
-    pub right_operand: Option<Box<Basis>>,
+    pub right_operand: Box<Basis>,
 }
 
 #[derive(Hash, Eq, PartialEq, Copy, Clone, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ mod basis;
 mod cards;
 mod game;
 
+mod math;
+
 // When the `wee_alloc` feature is enabled, this uses `wee_alloc` as the global
 // allocator.
 //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod cards;
 mod game;
 
 mod math;
+mod util;
 
 // When the `wee_alloc` feature is enabled, this uses `wee_alloc` as the global
 // allocator.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 use wasm_bindgen::prelude::*;
 use web_sys::console;
 
-mod basis;
-mod cards;
+pub mod basis;
+pub mod cards;
 mod game;
 
-mod math;
+pub mod math;
 mod util;
 
 // When the `wee_alloc` feature is enabled, this uses `wee_alloc` as the global

--- a/src/math/derivative.rs
+++ b/src/math/derivative.rs
@@ -1,0 +1,25 @@
+use std::collections::HashMap;
+
+use super::super::basis::*;
+
+fn atomic_derivative(basis: &BasisCard) -> BasisCard {
+    let derivative_lookup = HashMap::from([
+        (BasisCard::Cos, BasisCard::Sin),
+        (BasisCard::Sin, BasisCard::Cos),
+        (BasisCard::E, BasisCard::E),
+        (BasisCard::Zero, BasisCard::Zero),
+        (BasisCard::One, BasisCard::Zero),
+        (BasisCard::X, BasisCard::One),
+        (BasisCard::X2, BasisCard::X),
+    ]);
+    return derivative_lookup[basis];
+}
+
+pub fn derivative(basis: &Basis) -> Basis {
+    if basis.basis_type() == "BASIS_CARD" {
+        return Basis::BasisCard(atomic_derivative(&(basis.as_basis_card())));
+    } else {
+        // is complex basis
+        return Basis::BasisCard(BasisCard::Zero);
+    }
+}

--- a/src/math/derivative.rs
+++ b/src/math/derivative.rs
@@ -2,8 +2,6 @@ use std::collections::HashMap;
 
 use super::super::basis::*;
 
-use super::super::util::*;
-
 fn atomic_derivative(basis: &BasisCard) -> BasisCard {
     let derivative_lookup = HashMap::from([
         (BasisCard::Cos, BasisCard::Sin),
@@ -32,7 +30,7 @@ pub fn derivative(basis: &Basis) -> Basis {
                 derived_basis = Some(BasisNode {
                     operator: BasisOperator::Add,
                     left_operand: Box::new(derivative(&basis_node.left_operand)),
-                    right_operand: Some(Box::new(derivative(&basis_node.right_operand.unwrap()))),
+                    right_operand: Box::new(derivative(&basis_node.right_operand)),
                 });
             }
             BasisOperator::Div => {
@@ -43,22 +41,20 @@ pub fn derivative(basis: &Basis) -> Basis {
                         operator: BasisOperator::Minus, // vdu - udv
                         left_operand: Box::new(Basis::BasisNode(BasisNode {
                             operator: BasisOperator::Mult,
-                            left_operand: basis_node.right_operand.unwrap(), // v
-                            right_operand: Some(Box::new(derivative(&basis_node.left_operand))), // du
+                            left_operand: basis_node.right_operand, // v
+                            right_operand: Box::new(derivative(&basis_node.left_operand)), // du
                         })),
-                        right_operand: Some(Box::new(Basis::BasisNode(BasisNode {
+                        right_operand: Box::new(Basis::BasisNode(BasisNode {
                             operator: BasisOperator::Mult,
                             left_operand: basis_node.left_operand, // u
-                            right_operand: Some(Box::new(derivative(
-                                &basis_node.right_operand.unwrap(),
-                            ))), // dv
-                        }))),
+                            right_operand: Box::new(derivative(&basis_node.right_operand)), // dv
+                        })),
                     })),
-                    right_operand: Some(Box::new(Basis::BasisNode(BasisNode {
-                        operator: BasisOperator::Mult,                // uu
-                        left_operand: basis_node.left_operand,        // u
-                        right_operand: Some(basis_node.left_operand), // u
-                    }))),
+                    right_operand: Box::new(Basis::BasisNode(BasisNode {
+                        operator: BasisOperator::Mult,          // uu
+                        left_operand: basis_node.left_operand,  // u
+                        right_operand: basis_node.left_operand, // u
+                    })),
                 });
             }
             BasisOperator::Mult => {
@@ -68,15 +64,13 @@ pub fn derivative(basis: &Basis) -> Basis {
                     left_operand: Box::new(Basis::BasisNode(BasisNode {
                         operator: BasisOperator::Mult,
                         left_operand: basis_node.left_operand, // u
-                        right_operand: Some(Box::new(derivative(
-                            &basis_node.right_operand.unwrap(),
-                        ))), // dv
+                        right_operand: Box::new(derivative(&basis_node.right_operand)), // dv
                     })),
-                    right_operand: Some(Box::new(Basis::BasisNode(BasisNode {
+                    right_operand: Box::new(Basis::BasisNode(BasisNode {
                         operator: BasisOperator::Mult,
-                        left_operand: basis_node.right_operand.unwrap(), // v
-                        right_operand: Some(Box::new(derivative(&basis_node.left_operand))), // du
-                    }))),
+                        left_operand: basis_node.right_operand, // v
+                        right_operand: Box::new(derivative(&basis_node.left_operand)), // du
+                    })),
                 });
             }
             BasisOperator::Pow(n) => {
@@ -84,7 +78,7 @@ pub fn derivative(basis: &Basis) -> Basis {
                 derived_basis = Some(BasisNode {
                     operator: BasisOperator::Pow(n - 1), // n * x^(n-1), preceding n is discarded
                     left_operand: basis_node.left_operand,
-                    right_operand: None,
+                    right_operand: Box::new(Basis::BasisCard(BasisCard::Zero)), // dummy, unused
                 });
             }
         }

--- a/src/math/derivative.rs
+++ b/src/math/derivative.rs
@@ -23,26 +23,27 @@ pub fn derivative(basis: &Basis) -> Basis {
         // is complex basis
 
         // check here if operand passed in is actually a BasisCard
-        let mut derived_basis: Option<BasisNode> = None;
+
+        let derived_basis: BasisNode;
 
         match basis_node.operator {
             BasisOperator::Add => {
-                derived_basis = Some(BasisNode {
+                derived_basis = BasisNode {
                     operator: BasisOperator::Add,
                     left_operand: Box::new(derivative(&basis_node.left_operand)),
                     right_operand: Box::new(derivative(&basis_node.right_operand)),
-                });
+                };
             }
             BasisOperator::Minus => {
-                derived_basis = Some(BasisNode {
+                derived_basis = BasisNode {
                     operator: BasisOperator::Minus,
                     left_operand: Box::new(derivative(&basis_node.left_operand)),
                     right_operand: Box::new(derivative(&basis_node.right_operand)),
-                });
+                };
             }
             BasisOperator::Div => {
                 // quotient rule here
-                derived_basis = Some(BasisNode {
+                derived_basis = BasisNode {
                     operator: BasisOperator::Div, // (vdu - udv) / uu
                     left_operand: Box::new(Basis::BasisNode(BasisNode {
                         operator: BasisOperator::Minus, // vdu - udv
@@ -62,11 +63,11 @@ pub fn derivative(basis: &Basis) -> Basis {
                         left_operand: basis_node.left_operand.clone(),  // u
                         right_operand: basis_node.left_operand.clone(), // u
                     })),
-                });
+                };
             }
             BasisOperator::Mult => {
                 // product rule
-                derived_basis = Some(BasisNode {
+                derived_basis = BasisNode {
                     operator: BasisOperator::Add, // udv + vdu
                     left_operand: Box::new(Basis::BasisNode(BasisNode {
                         operator: BasisOperator::Mult,
@@ -78,19 +79,19 @@ pub fn derivative(basis: &Basis) -> Basis {
                         left_operand: basis_node.right_operand.clone(), // v
                         right_operand: Box::new(derivative(&basis_node.left_operand)), // du
                     })),
-                });
+                };
             }
             BasisOperator::Pow(n) => {
                 // power rule
-                derived_basis = Some(BasisNode {
+                derived_basis = BasisNode {
                     operator: BasisOperator::Pow(n - 1), // n * x^(n-1), preceding n is discarded
                     left_operand: basis_node.left_operand.clone(),
                     right_operand: Box::new(Basis::BasisCard(BasisCard::Zero)), // dummy, unused
-                });
+                };
             }
         }
 
-        return Basis::BasisNode(derived_basis.unwrap());
+        return Basis::BasisNode(derived_basis);
     } else {
         // should never be called
         Basis::BasisCard(BasisCard::Zero)

--- a/src/math/derivative.rs
+++ b/src/math/derivative.rs
@@ -48,19 +48,19 @@ pub fn derivative(basis: &Basis) -> Basis {
                         operator: BasisOperator::Minus, // vdu - udv
                         left_operand: Box::new(Basis::BasisNode(BasisNode {
                             operator: BasisOperator::Mult,
-                            left_operand: basis_node.right_operand, // v
+                            left_operand: basis_node.right_operand.clone(), // v
                             right_operand: Box::new(derivative(&basis_node.left_operand)), // du
                         })),
                         right_operand: Box::new(Basis::BasisNode(BasisNode {
                             operator: BasisOperator::Mult,
-                            left_operand: basis_node.left_operand, // u
+                            left_operand: basis_node.left_operand.clone(), // u
                             right_operand: Box::new(derivative(&basis_node.right_operand)), // dv
                         })),
                     })),
                     right_operand: Box::new(Basis::BasisNode(BasisNode {
-                        operator: BasisOperator::Mult,          // uu
-                        left_operand: basis_node.left_operand,  // u
-                        right_operand: basis_node.left_operand, // u
+                        operator: BasisOperator::Mult,                  // uu
+                        left_operand: basis_node.left_operand.clone(),  // u
+                        right_operand: basis_node.left_operand.clone(), // u
                     })),
                 });
             }
@@ -70,12 +70,12 @@ pub fn derivative(basis: &Basis) -> Basis {
                     operator: BasisOperator::Add, // udv + vdu
                     left_operand: Box::new(Basis::BasisNode(BasisNode {
                         operator: BasisOperator::Mult,
-                        left_operand: basis_node.left_operand, // u
+                        left_operand: basis_node.left_operand.clone(), // u
                         right_operand: Box::new(derivative(&basis_node.right_operand)), // dv
                     })),
                     right_operand: Box::new(Basis::BasisNode(BasisNode {
                         operator: BasisOperator::Mult,
-                        left_operand: basis_node.right_operand, // v
+                        left_operand: basis_node.right_operand.clone(), // v
                         right_operand: Box::new(derivative(&basis_node.left_operand)), // du
                     })),
                 });
@@ -84,7 +84,7 @@ pub fn derivative(basis: &Basis) -> Basis {
                 // power rule
                 derived_basis = Some(BasisNode {
                     operator: BasisOperator::Pow(n - 1), // n * x^(n-1), preceding n is discarded
-                    left_operand: basis_node.left_operand,
+                    left_operand: basis_node.left_operand.clone(),
                     right_operand: Box::new(Basis::BasisCard(BasisCard::Zero)), // dummy, unused
                 });
             }

--- a/src/math/derivative.rs
+++ b/src/math/derivative.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 
 use super::super::basis::*;
 
+use super::super::util::*;
+
 fn atomic_derivative(basis: &BasisCard) -> BasisCard {
     let derivative_lookup = HashMap::from([
         (BasisCard::Cos, BasisCard::Sin),
@@ -17,9 +19,10 @@ fn atomic_derivative(basis: &BasisCard) -> BasisCard {
 
 pub fn derivative(basis: &Basis) -> Basis {
     if basis.basis_type() == "BASIS_CARD" {
-        return Basis::BasisCard(atomic_derivative(&(basis.as_basis_card())));
+        return Basis::BasisCard(atomic_derivative(&enum_cast!(basis, Basis::BasisCard)));
     } else {
         // is complex basis
+        // let complex_basis = basis.as_basis_node();
         return Basis::BasisCard(BasisCard::Zero);
     }
 }

--- a/src/math/derivative.rs
+++ b/src/math/derivative.rs
@@ -74,8 +74,8 @@ pub fn derivative(basis: &Basis) -> Basis {
                 return PowBasisNode(n - 1, &*basis_node.left_operand);
             }
             BasisOperator::Sqrt(n) => {
-                // power rule, n * x^(n-1) : preceding n is discarded
-                return SqrtBasisNode(n - 1, &*basis_node.left_operand);
+                // power rule, n/2 * x^(n/2-1) : preceding n is discarded
+                return SqrtBasisNode(n - 2, &*basis_node.left_operand);
             }
         }
     }

--- a/src/math/derivative.rs
+++ b/src/math/derivative.rs
@@ -18,11 +18,23 @@ fn atomic_derivative(basis: &BasisCard) -> BasisCard {
 }
 
 pub fn derivative(basis: &Basis) -> Basis {
-    if basis.basis_type() == "BASIS_CARD" {
-        return Basis::BasisCard(atomic_derivative(&enum_cast!(basis, Basis::BasisCard)));
-    } else {
+    if let Basis::BasisCard(basis_card) = basis {
+        // is standard basis
+        return Basis::BasisCard(atomic_derivative(&basis_card));
+    } else if let Basis::BasisNode(basis_node) = basis {
         // is complex basis
-        // let complex_basis = basis.as_basis_node();
-        return Basis::BasisCard(BasisCard::Zero);
+
+        match basis_node.operator {
+            BasisOperator::Add => {}
+            BasisOperator::Div => {}
+            BasisOperator::Mult => {}
+            BasisOperator::Pow(_) => {}
+        }
+
+        // fallback
+        return Basis::BasisNode(*basis_node);
+    } else {
+        // should never be called
+        Basis::BasisCard(BasisCard::Zero)
     }
 }

--- a/src/math/derivative.rs
+++ b/src/math/derivative.rs
@@ -89,6 +89,14 @@ pub fn derivative(basis: &Basis) -> Basis {
                     right_operand: Box::new(Basis::BasisCard(BasisCard::Zero)), // dummy, unused
                 };
             }
+            BasisOperator::Sqrt(n) => {
+                // power rule
+                derived_basis = BasisNode {
+                    operator: BasisOperator::Sqrt(n - 1), // n * x^(n-1), preceding n is discarded
+                    left_operand: basis_node.left_operand.clone(),
+                    right_operand: Box::new(Basis::BasisCard(BasisCard::Zero)), // dummy, unused
+                };
+            }
         }
 
         return Basis::BasisNode(derived_basis);

--- a/src/math/derivative.rs
+++ b/src/math/derivative.rs
@@ -33,6 +33,13 @@ pub fn derivative(basis: &Basis) -> Basis {
                     right_operand: Box::new(derivative(&basis_node.right_operand)),
                 });
             }
+            BasisOperator::Minus => {
+                derived_basis = Some(BasisNode {
+                    operator: BasisOperator::Minus,
+                    left_operand: Box::new(derivative(&basis_node.left_operand)),
+                    right_operand: Box::new(derivative(&basis_node.right_operand)),
+                });
+            }
             BasisOperator::Div => {
                 // quotient rule here
                 derived_basis = Some(BasisNode {

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -1,0 +1,1 @@
+mod derivative;

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -1,1 +1,1 @@
-mod derivative;
+pub mod derivative;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,16 @@
+macro_rules! enum_cast {
+    // tries to cast enum to variant
+    ($enum: expr, $variant: path) => {{
+        // if variant is a valid member of enum
+        if let $variant(output) = $enum {
+            *output
+        } else {
+            panic!(
+                "mismatch variant when casting {} to {}",
+                stringify!($enum),
+                stringify!($variant)
+            );
+        }
+    }};
+}
+pub(crate) use enum_cast;

--- a/tests/app.rs
+++ b/tests/app.rs
@@ -1,10 +1,10 @@
-use wasm_bindgen_test::{wasm_bindgen_test_configure, wasm_bindgen_test};
-use futures::prelude::*;
 use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::JsFuture;
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+use futures::prelude::*;
 
 wasm_bindgen_test_configure!(run_in_browser);
-
 
 // This runs a unit test in native Rust, so it can only use Rust APIs.
 #[test]
@@ -12,13 +12,11 @@ fn rust_test() {
     assert_eq!(1, 1);
 }
 
-
 // This runs a unit test in the browser, so it can use browser APIs.
 #[wasm_bindgen_test]
 fn web_test() {
     assert_eq!(1, 1);
 }
-
 
 // This runs a unit test in the browser, and in addition it supports asynchronous Future APIs.
 #[wasm_bindgen_test(async)]
@@ -28,8 +26,5 @@ fn async_test() -> impl Future<Item = (), Error = JsValue> {
 
     // Converts that Promise into a Future.
     // The unit test will wait for the Future to resolve.
-    JsFuture::from(promise)
-        .map(|x| {
-            assert_eq!(x, 42);
-        })
+    JsFuture::from(promise).map(|x| assert_eq!(x, 42))
 }

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -1,0 +1,96 @@
+use nabla_game;
+
+use nabla_game::basis::*;
+use nabla_game::math::*;
+
+// test all atomic derivatives
+#[test]
+fn test_atomic_derivatives() {
+    assert_eq!(
+        derivative::derivative(&Basis::BasisCard(BasisCard::Cos)),
+        Basis::BasisCard(BasisCard::Sin),
+    );
+    assert_eq!(
+        derivative::derivative(&Basis::BasisCard(BasisCard::Sin)),
+        Basis::BasisCard(BasisCard::Cos),
+    );
+    assert_eq!(
+        derivative::derivative(&Basis::BasisCard(BasisCard::E)),
+        Basis::BasisCard(BasisCard::E),
+    );
+    assert_eq!(
+        derivative::derivative(&Basis::BasisCard(BasisCard::Zero)),
+        Basis::BasisCard(BasisCard::Zero),
+    );
+    assert_eq!(
+        derivative::derivative(&Basis::BasisCard(BasisCard::One)),
+        Basis::BasisCard(BasisCard::Zero),
+    );
+    assert_eq!(
+        derivative::derivative(&Basis::BasisCard(BasisCard::X)),
+        Basis::BasisCard(BasisCard::One),
+    );
+    assert_eq!(
+        derivative::derivative(&Basis::BasisCard(BasisCard::X2)),
+        Basis::BasisCard(BasisCard::X),
+    );
+}
+
+#[test]
+fn test_add_derivative() {
+    // test first derivative
+    assert_eq!(
+        // dx(x + e^x)
+        derivative::derivative(&Basis::BasisNode(BasisNode {
+            operator: BasisOperator::Add,
+            left_operand: Box::new(Basis::BasisCard(BasisCard::X)),
+            right_operand: Box::new(Basis::BasisCard(BasisCard::E)),
+        })),
+        // 1 + e^x
+        Basis::BasisNode(BasisNode {
+            operator: BasisOperator::Add,
+            left_operand: Box::new(Basis::BasisCard(BasisCard::One)),
+            right_operand: Box::new(Basis::BasisCard(BasisCard::E)),
+        })
+    );
+
+    // test second derivative
+    assert_eq!(
+        // dx(dx(cos(x) + x^2))
+        derivative::derivative(&derivative::derivative(&Basis::BasisNode(BasisNode {
+            operator: BasisOperator::Add,
+            left_operand: Box::new(Basis::BasisCard(BasisCard::Cos)),
+            right_operand: Box::new(Basis::BasisCard(BasisCard::X2)),
+        }))),
+        // cos(x) + 1
+        Basis::BasisNode(BasisNode {
+            operator: BasisOperator::Add,
+            left_operand: Box::new(Basis::BasisCard(BasisCard::Cos)),
+            right_operand: Box::new(Basis::BasisCard(BasisCard::One)),
+        })
+    );
+
+    // test trinomial (nested BasisNode)
+    assert_eq!(
+        // dx(sin(x) + x^2 + x)
+        derivative::derivative(&Basis::BasisNode(BasisNode {
+            operator: BasisOperator::Add,
+            left_operand: Box::new(Basis::BasisNode(BasisNode {
+                operator: BasisOperator::Add,
+                left_operand: Box::new(Basis::BasisCard(BasisCard::Sin)),
+                right_operand: Box::new(Basis::BasisCard(BasisCard::X2)),
+            })),
+            right_operand: Box::new(Basis::BasisCard(BasisCard::X)),
+        })),
+        // cos(x) + x + 1
+        Basis::BasisNode(BasisNode {
+            operator: BasisOperator::Add,
+            left_operand: Box::new(Basis::BasisNode(BasisNode {
+                operator: BasisOperator::Add,
+                left_operand: Box::new(Basis::BasisCard(BasisCard::Cos)),
+                right_operand: Box::new(Basis::BasisCard(BasisCard::X)),
+            })),
+            right_operand: Box::new(Basis::BasisCard(BasisCard::One)),
+        })
+    );
+}

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -26,8 +26,9 @@ fn test_atomic_derivatives() {
     }
 }
 
+// test Add and Minus derivatives
 #[test]
-fn test_add_derivative() {
+fn test_add_derivatives() {
     // test first derivative
     assert_eq!(
         // dx(x + e^x)
@@ -74,5 +75,111 @@ fn test_add_derivative() {
             ),
             &Basis::BasisCard(BasisCard::One)
         )
+    );
+
+    // test trim 0
+    assert_eq!(
+        // dx(cos(x) + x)
+        derivative::derivative(&AddBasisNode(
+            &Basis::BasisCard(BasisCard::Cos),
+            &Basis::BasisCard(BasisCard::One),
+        )),
+        // sin(x)
+        Basis::BasisCard(BasisCard::Sin)
+    );
+}
+
+// test Mult and Div derivatives
+#[test]
+fn test_mult_derivatives() {
+    // test mult derivative
+    assert_eq!(
+        // dx(x^2 * cos(x))
+        derivative::derivative(&MultBasisNode(
+            &Basis::BasisCard(BasisCard::X2),
+            &Basis::BasisCard(BasisCard::Cos),
+        )),
+        //  x^2*sin(x) + cos(x)*x
+        AddBasisNode(
+            &MultBasisNode(
+                &Basis::BasisCard(BasisCard::X2),
+                &Basis::BasisCard(BasisCard::Sin),
+            ),
+            &MultBasisNode(
+                &Basis::BasisCard(BasisCard::Cos),
+                &Basis::BasisCard(BasisCard::X),
+            ),
+        )
+    );
+
+    // test trim 1
+    assert_eq!(
+        // dx(x * e^x)
+        derivative::derivative(&MultBasisNode(
+            &Basis::BasisCard(BasisCard::X),
+            &Basis::BasisCard(BasisCard::E),
+        )),
+        //  x*e^x + e^x
+        AddBasisNode(
+            &MultBasisNode(
+                &Basis::BasisCard(BasisCard::X),
+                &Basis::BasisCard(BasisCard::E),
+            ),
+            &Basis::BasisCard(BasisCard::E)
+        )
+    );
+
+    // test div derivative
+    assert_eq!(
+        // dx(cos(x) / e^x)
+        derivative::derivative(&DivBasisNode(
+            &Basis::BasisCard(BasisCard::Cos),
+            &Basis::BasisCard(BasisCard::E),
+        )),
+        //  x^2*sin(x) + cos(x)*x
+        DivBasisNode(
+            &MinusBasisNode(
+                &MultBasisNode(
+                    &Basis::BasisCard(BasisCard::E),
+                    &Basis::BasisCard(BasisCard::Sin),
+                ),
+                &MultBasisNode(
+                    &Basis::BasisCard(BasisCard::Cos),
+                    &Basis::BasisCard(BasisCard::E),
+                )
+            ),
+            &MultBasisNode(
+                &Basis::BasisCard(BasisCard::Cos),
+                &Basis::BasisCard(BasisCard::Cos),
+            ),
+        )
+    );
+}
+
+// test Pow and Sqrt derivatives
+#[test]
+fn test_exponent_derivatives() {
+    // test pow derivative
+    assert_eq!(
+        // dx(x^4)
+        derivative::derivative(&PowBasisNode(4, &Basis::BasisCard(BasisCard::X))),
+        // x^3
+        PowBasisNode(3, &Basis::BasisCard(BasisCard::X))
+    );
+
+    // test trim to X2
+    assert_eq!(
+        // dx(x^3)
+        derivative::derivative(&PowBasisNode(3, &Basis::BasisCard(BasisCard::X))),
+        // x^3
+        Basis::BasisCard(BasisCard::X2)
+    );
+
+    // test Sqrt derivative
+    assert_eq!(
+        // dx(x^1/2)
+        derivative::derivative(&SqrtBasisNode(1, &Basis::BasisCard(BasisCard::X))),
+        // x^-1/2
+        SqrtBasisNode(-1, &Basis::BasisCard(BasisCard::X))
     );
 }

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -148,10 +148,7 @@ fn test_mult_derivatives() {
                     &Basis::BasisCard(BasisCard::E),
                 )
             ),
-            &MultBasisNode(
-                &Basis::BasisCard(BasisCard::Cos),
-                &Basis::BasisCard(BasisCard::Cos),
-            ),
+            &PowBasisNode(2, &Basis::BasisCard(BasisCard::Cos),),
         )
     );
 }


### PR DESCRIPTION
- adds basic derivative support for Bases, represent as binary tree of BasisOperators (Pow, Mult, Div, Add, Minus) and BasisCard leaves
  - performs derivatives on BasisCards via hashmap lookup table
  - does not yet have leaf pruning / tree restructuring
- added tests for derivative function