### PR TITLE
Add Typescript bindings for Rust types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "futures"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +54,12 @@ dependencies = [
  "wasi",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
@@ -94,6 +106,8 @@ dependencies = [
  "getrandom",
  "js-sys",
  "rand",
+ "serde",
+ "serde-wasm-bindgen",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -184,10 +198,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
+name = "serde"
+version = "1.0.133"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5cefe81e058ce25d1acbd79160e110d2eb4b9459024d46818d7553e4be6ff7e"
+dependencies = [
+ "fnv",
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.133"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+dependencies = [
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "syn"
@@ -225,6 +288,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if 1.0.0",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ lto = true
 [dependencies]
 # The `wasm-bindgen` crate provides the bare minimum functionality needed
 # to interact with JavaScript.
+wasm-bindgen = { version = "0.2.45", features = ["serde-serialize"] }
+serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.4.1"
 
 getrandom = { version = "0.2.3", features = ["js"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ lto = true
 [dependencies]
 # The `wasm-bindgen` crate provides the bare minimum functionality needed
 # to interact with JavaScript.
-wasm-bindgen = "0.2.45"
+serde-wasm-bindgen = "0.4.1"
 
 getrandom = { version = "0.2.3", features = ["js"] }
 rand = "0.8.4"

--- a/js/index.js
+++ b/js/index.js
@@ -1,8 +1,6 @@
 import('../pkg/index.js')
 	.then(module => {
-		module.main_js();
-		// module.game.test_new();
-		console.log(module);
+		// module.main_js();
 		console.log(new module.Game());
 	})
 	.catch(console.error);

--- a/js/index.js
+++ b/js/index.js
@@ -1,1 +1,8 @@
-import("../pkg/index.js").catch(console.error);
+import('../pkg/index.js')
+	.then(module => {
+		module.main_js();
+		// module.game.test_new();
+		console.log(module);
+		console.log(new module.Game());
+	})
+	.catch(console.error);

--- a/js/index.ts
+++ b/js/index.ts
@@ -1,6 +1,8 @@
 import('../pkg/index.js')
 	.then(module => {
 		// module.main_js();
-		console.log(new module.Game());
+		let game = new module.Game();
+
+		console.log(game);
 	})
 	.catch(console.error);

--- a/src/basis.rs
+++ b/src/basis.rs
@@ -11,6 +11,7 @@ pub enum Basis {
 }
 
 // used for complex bases derived from the starter cards
+// #[wasm_bindgen]
 #[derive(Debug)]
 pub struct BasisNode {
     pub operator: BasisOperator,
@@ -60,7 +61,8 @@ impl EnumStr<BasisCard> for BasisCard {
     }
 }
 
-#[derive(Debug)]
+#[wasm_bindgen]
+#[derive(Copy, Clone, Debug)]
 pub enum BasisOperator {
     Mult,
     Add,

--- a/src/basis.rs
+++ b/src/basis.rs
@@ -11,6 +11,17 @@ pub enum Basis {
     BasisCard(BasisCard),
 }
 
+#[wasm_bindgen(typescript_custom_section)]
+const IBASIS: &'static str = r#"
+export type Basis = BasisNode | BasisCard;
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "IBasis")]
+    pub type IBasis;
+}
+
 // used for complex bases derived from the starter cards
 // #[wasm_bindgen]
 #[derive(Debug, Serialize, Deserialize)]
@@ -21,6 +32,20 @@ pub struct BasisNode {
     // nested bases for complex bases
     // 2 items only for pow, div (use [Basis; 2] ?)
     // mult, add could be arbitrary num (usually 2, maybe 3)
+}
+
+#[wasm_bindgen(typescript_custom_section)]
+const IBASIS_NODE: &'static str = r#"
+export interface BasisNode {
+    operator: BasisOperator;
+    operands: Basis[];
+}
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "IBasisNode")]
+    pub type IBasisNode;
 }
 
 #[wasm_bindgen]

--- a/src/basis.rs
+++ b/src/basis.rs
@@ -1,10 +1,11 @@
+use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 use super::game::EnumStr;
 
 // type union of the starter basis or complex basis
 // #[wasm_bindgen]
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum Basis {
     BasisNode(BasisNode),
     BasisCard(BasisCard),
@@ -12,7 +13,7 @@ pub enum Basis {
 
 // used for complex bases derived from the starter cards
 // #[wasm_bindgen]
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct BasisNode {
     pub operator: BasisOperator,
     // Vec heap allocates, prevents recursive struct reference
@@ -23,7 +24,7 @@ pub struct BasisNode {
 }
 
 #[wasm_bindgen]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub enum BasisCard {
     Zero,
     One,
@@ -62,7 +63,7 @@ impl EnumStr<BasisCard> for BasisCard {
 }
 
 #[wasm_bindgen]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub enum BasisOperator {
     Mult,
     Add,

--- a/src/basis.rs
+++ b/src/basis.rs
@@ -1,6 +1,9 @@
+use wasm_bindgen::prelude::*;
+
 use super::game::EnumStr;
 
 // type union of the starter basis or complex basis
+// #[wasm_bindgen]
 #[derive(Debug)]
 pub enum Basis {
     BasisNode(BasisNode),
@@ -17,6 +20,8 @@ pub struct BasisNode {
     // 2 items only for pow, div (use [Basis; 2] ?)
     // mult, add could be arbitrary num (usually 2, maybe 3)
 }
+
+#[wasm_bindgen]
 #[derive(Copy, Clone, Debug)]
 pub enum BasisCard {
     Zero,

--- a/src/cards.rs
+++ b/src/cards.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-// use wasm_bindgen::prelude::*;
+use wasm_bindgen::prelude::*;
 
 use super::basis::BasisCard;
 use super::game::EnumStr;
@@ -18,6 +18,17 @@ pub enum Card {
     AlgebraicCard(AlgebraicCard),
 }
 
+#[wasm_bindgen(typescript_custom_section)]
+const ICARD: &'static str = r#"
+export type Card = BasisCard | LimitCard | DerivativeCard | AlgebraicCard;
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "ICard")]
+    pub type ICard;
+}
+
 impl CardType for Card {
     fn card_type(&self) -> &'static str {
         match self {
@@ -29,6 +40,7 @@ impl CardType for Card {
     }
 }
 
+#[wasm_bindgen]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub enum LimitCard {
     LimPosInf,
@@ -61,6 +73,7 @@ impl EnumStr<LimitCard> for LimitCard {
     }
 }
 
+#[wasm_bindgen]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub enum DerivativeCard {
     Derivative,
@@ -90,6 +103,7 @@ impl EnumStr<DerivativeCard> for DerivativeCard {
     }
 }
 
+#[wasm_bindgen]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub enum AlgebraicCard {
     Div,

--- a/src/cards.rs
+++ b/src/cards.rs
@@ -1,4 +1,5 @@
-use wasm_bindgen::prelude::*;
+use serde::{Deserialize, Serialize};
+// use wasm_bindgen::prelude::*;
 
 use super::basis::BasisCard;
 use super::game::EnumStr;
@@ -9,7 +10,7 @@ pub trait CardType {
 
 // type union of basis cards or operator cards
 // #[wasm_bindgen]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub enum Card {
     BasisCard(BasisCard),
     LimitCard(LimitCard),
@@ -28,7 +29,7 @@ impl CardType for Card {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub enum LimitCard {
     LimPosInf,
     LimNegInf,
@@ -60,7 +61,7 @@ impl EnumStr<LimitCard> for LimitCard {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub enum DerivativeCard {
     Derivative,
     Nabla,
@@ -89,7 +90,7 @@ impl EnumStr<DerivativeCard> for DerivativeCard {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub enum AlgebraicCard {
     Div,
     Mult,

--- a/src/cards.rs
+++ b/src/cards.rs
@@ -1,3 +1,5 @@
+use wasm_bindgen::prelude::*;
+
 use super::basis::BasisCard;
 use super::game::EnumStr;
 
@@ -6,6 +8,7 @@ pub trait CardType {
 }
 
 // type union of basis cards or operator cards
+// #[wasm_bindgen]
 #[derive(Copy, Clone, Debug)]
 pub enum Card {
     BasisCard(BasisCard),

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,8 +1,8 @@
+use serde::{Deserialize, Serialize};
 use serde_wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
-use rand::seq::SliceRandom;
-use rand::thread_rng;
+use rand::{seq::SliceRandom, thread_rng};
 
 use super::basis::*;
 use super::cards::*;
@@ -41,7 +41,7 @@ fn create_players(deck: &mut Vec<Card>) -> (Vec<Card>, Vec<Card>) {
 
     // check for edge case where a player receives all basis cards
     while hand_1.iter().all(|card| card.card_type() == "BASIS_CARD")
-        && hand_2.iter().all(|card| card.card_type() == "BASIS_CARD")
+        || hand_2.iter().all(|card| card.card_type() == "BASIS_CARD")
     {
         // mulligan and re shuffle
         deck.append(&mut hand_1);
@@ -55,7 +55,7 @@ fn create_players(deck: &mut Vec<Card>) -> (Vec<Card>, Vec<Card>) {
 }
 
 // #[wasm_bindgen]
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Game {
     pub turn_number: i32,          // turn counter
     pub field: [Option<Basis>; 6], // [0-2] for player_1, [3-5] for player_2
@@ -66,34 +66,30 @@ pub struct Game {
 
 #[wasm_bindgen]
 impl Game {
-    // #[wasm_bindgen(constructor)]
-    // pub fn new() -> Game {
-    //     let mut deck = get_new_deck();
-    //     deck.shuffle(&mut thread_rng());
-
-    //     let (player_1, player_2) = create_players(&mut deck);
-    //     return Game {
-    //         turn_number: 0,
-    //         field: [
-    //             Some(Basis::BasisCard(BasisCard::One)),
-    //             Some(Basis::BasisCard(BasisCard::X)),
-    //             Some(Basis::BasisCard(BasisCard::X2)),
-    //             Some(Basis::BasisCard(BasisCard::One)),
-    //             Some(Basis::BasisCard(BasisCard::X)),
-    //             Some(Basis::BasisCard(BasisCard::X2)),
-    //         ],
-    //         player_1: player_1,
-    //         player_2: player_2,
-    //         deck: deck,
-    //     };
-    // }
-
     #[wasm_bindgen(constructor)]
-    pub fn test_new() -> Result<JsValue, JsValue> {
-        let some_supported_rust_value = ("Hello, world!", 42);
-        let js_value = serde_wasm_bindgen::to_value(&some_supported_rust_value)?;
-        // ...
-        Ok(js_value)
+    pub fn new() -> Result<JsValue, JsValue> {
+        let mut deck = get_new_deck();
+        deck.shuffle(&mut thread_rng());
+
+        let (player_1, player_2) = create_players(&mut deck);
+        let game = Game {
+            turn_number: 0,
+            field: [
+                Some(Basis::BasisCard(BasisCard::One)),
+                Some(Basis::BasisCard(BasisCard::X)),
+                Some(Basis::BasisCard(BasisCard::X2)),
+                Some(Basis::BasisCard(BasisCard::One)),
+                Some(Basis::BasisCard(BasisCard::X)),
+                Some(Basis::BasisCard(BasisCard::X2)),
+            ],
+            player_1: player_1,
+            player_2: player_2,
+            deck: deck,
+        };
+
+        let js_game = serde_wasm_bindgen::to_value(&game)?;
+
+        Ok(js_game)
     }
 }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,3 +1,4 @@
+use serde_wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
 use rand::seq::SliceRandom;
@@ -63,28 +64,36 @@ pub struct Game {
     pub deck: Vec<Card>,
 }
 
-// #[wasm_bindgen]
+#[wasm_bindgen]
 impl Game {
     // #[wasm_bindgen(constructor)]
-    pub fn new() -> Game {
-        let mut deck = get_new_deck();
-        deck.shuffle(&mut thread_rng());
+    // pub fn new() -> Game {
+    //     let mut deck = get_new_deck();
+    //     deck.shuffle(&mut thread_rng());
 
-        let (player_1, player_2) = create_players(&mut deck);
-        return Game {
-            turn_number: 0,
-            field: [
-                Some(Basis::BasisCard(BasisCard::One)),
-                Some(Basis::BasisCard(BasisCard::X)),
-                Some(Basis::BasisCard(BasisCard::X2)),
-                Some(Basis::BasisCard(BasisCard::One)),
-                Some(Basis::BasisCard(BasisCard::X)),
-                Some(Basis::BasisCard(BasisCard::X2)),
-            ],
-            player_1: player_1,
-            player_2: player_2,
-            deck: deck,
-        };
+    //     let (player_1, player_2) = create_players(&mut deck);
+    //     return Game {
+    //         turn_number: 0,
+    //         field: [
+    //             Some(Basis::BasisCard(BasisCard::One)),
+    //             Some(Basis::BasisCard(BasisCard::X)),
+    //             Some(Basis::BasisCard(BasisCard::X2)),
+    //             Some(Basis::BasisCard(BasisCard::One)),
+    //             Some(Basis::BasisCard(BasisCard::X)),
+    //             Some(Basis::BasisCard(BasisCard::X2)),
+    //         ],
+    //         player_1: player_1,
+    //         player_2: player_2,
+    //         deck: deck,
+    //     };
+    // }
+
+    #[wasm_bindgen(constructor)]
+    pub fn test_new() -> Result<JsValue, JsValue> {
+        let some_supported_rust_value = ("Hello, world!", 42);
+        let js_value = serde_wasm_bindgen::to_value(&some_supported_rust_value)?;
+        // ...
+        Ok(js_value)
     }
 }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -64,6 +64,23 @@ pub struct Game {
     pub deck: Vec<Card>,
 }
 
+#[wasm_bindgen(typescript_custom_section)]
+const IGAME: &'static str = r#"
+export interface Game {
+    turn_number: number;
+    field: number[];
+    player_1: Card[];
+    player_2: Card[];
+    deck: Card[];
+}
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "IGame")]
+    pub type IGame;
+}
+
 #[wasm_bindgen]
 impl Game {
     #[wasm_bindgen(constructor)]

--- a/src/game.rs
+++ b/src/game.rs
@@ -53,29 +53,6 @@ fn create_players(deck: &mut Vec<Card>) -> (Vec<Card>, Vec<Card>) {
     (hand_1, hand_2)
 }
 
-pub fn build_game() -> Game {
-    let mut deck = get_new_deck();
-    deck.shuffle(&mut thread_rng());
-
-    let players = create_players(&mut deck);
-    let game = Game {
-        turn_number: 0,
-        field: [
-            Some(Basis::BasisCard(BasisCard::One)),
-            Some(Basis::BasisCard(BasisCard::X)),
-            Some(Basis::BasisCard(BasisCard::X2)),
-            Some(Basis::BasisCard(BasisCard::One)),
-            Some(Basis::BasisCard(BasisCard::X)),
-            Some(Basis::BasisCard(BasisCard::X2)),
-        ],
-        player_1: players.0,
-        player_2: players.1,
-        deck: deck,
-    };
-
-    return game;
-}
-
 // #[wasm_bindgen]
 #[derive(Debug)]
 pub struct Game {
@@ -84,6 +61,31 @@ pub struct Game {
     pub player_1: Vec<Card>,       // up to 7 cards in hand (<7 if deck running low)
     pub player_2: Vec<Card>,
     pub deck: Vec<Card>,
+}
+
+// #[wasm_bindgen]
+impl Game {
+    // #[wasm_bindgen(constructor)]
+    pub fn new() -> Game {
+        let mut deck = get_new_deck();
+        deck.shuffle(&mut thread_rng());
+
+        let (player_1, player_2) = create_players(&mut deck);
+        return Game {
+            turn_number: 0,
+            field: [
+                Some(Basis::BasisCard(BasisCard::One)),
+                Some(Basis::BasisCard(BasisCard::X)),
+                Some(Basis::BasisCard(BasisCard::X2)),
+                Some(Basis::BasisCard(BasisCard::One)),
+                Some(Basis::BasisCard(BasisCard::X)),
+                Some(Basis::BasisCard(BasisCard::X2)),
+            ],
+            player_1: player_1,
+            player_2: player_2,
+            deck: deck,
+        };
+    }
 }
 
 // TODO: move this to util file

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use web_sys::console;
 
 mod basis;
 mod cards;
-mod game;
+pub mod game;
 
 // When the `wee_alloc` feature is enabled, this uses `wee_alloc` as the global
 // allocator.
@@ -22,11 +22,11 @@ pub fn main_js() -> Result<(), JsValue> {
     console_error_panic_hook::set_once();
 
     // Your code goes here!
-    console::log_1(&JsValue::from_str("Hello world!"));
+    // console::log_1(&JsValue::from_str("Hello world!"));
 
-    let game = game::Game::new();
+    // let game = game::Game::new();
 
-    console::log_1(&JsValue::from_str(&format!("{:?}", &game)));
+    // console::log_1(&JsValue::from_str(&format!("{:?}", &game)));
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 use wasm_bindgen::prelude::*;
 use web_sys::console;
 
-mod basis;
-mod cards;
+pub mod basis;
+pub mod cards;
 pub mod game;
 
 // When the `wee_alloc` feature is enabled, this uses `wee_alloc` as the global

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,13 +20,5 @@ pub fn main_js() -> Result<(), JsValue> {
     // It's disabled in release mode so it doesn't bloat up the file size.
     #[cfg(debug_assertions)]
     console_error_panic_hook::set_once();
-
-    // Your code goes here!
-    // console::log_1(&JsValue::from_str("Hello world!"));
-
-    // let game = game::Game::new();
-
-    // console::log_1(&JsValue::from_str(&format!("{:?}", &game)));
-
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub fn main_js() -> Result<(), JsValue> {
     // Your code goes here!
     console::log_1(&JsValue::from_str("Hello world!"));
 
-    let game = game::build_game();
+    let game = game::Game::new();
 
     console::log_1(&JsValue::from_str(&format!("{:?}", &game)));
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ const dist = path.resolve(__dirname, 'dist');
 module.exports = {
 	mode: 'production',
 	entry: {
-		index: './js/index.js',
+		index: './js/index.ts',
 	},
 	output: {
 		path: dist,
@@ -21,10 +21,12 @@ module.exports = {
 			},
 		],
 	},
-	// temp, see: https://github.com/rust-random/getrandom/issues/224
 	ignoreWarnings: [
+		// temp, see: https://github.com/rust-random/getrandom/issues/224
 		warning =>
 			warning.message === 'Critical dependency: the request of a dependency is an expression',
+		// warning message caused by wasm-bindgen + webpack
+		warning => /__wbg.+free/.test(warning.message),
 	],
 	experiments: {
 		syncWebAssembly: true,


### PR DESCRIPTION
- added Serde dep to send Rust objects as JsValue to browser (currently unable to use wasm-bindgen on Variant Enums and Trait impls)
- added custom_typescript_sections that denote TS types